### PR TITLE
Fix for broken build in xcode 9.1 (swift 4).

### DIFF
--- a/Sources/DataRequestOperation.swift
+++ b/Sources/DataRequestOperation.swift
@@ -127,6 +127,7 @@ open class DataRequestOperation<R: Requestable>: Operation {
         executeRequest()
     }
     
+    @objc
     func executeRequest() {
         request = AlamofireUtils.alamofireDataRequestFromRequestable(requestable)
         request.response(queue: requestable.queue, responseSerializer: requestable.dataResponseSerializer) { (response: Alamofire.DataResponse<Any>) in


### PR DESCRIPTION
This fix was not present in the awaiting pull-request #21. Restofire was not building for me on xcode 9.1 running swift 4.