### PR TITLE
feat: Request Delegates #32

### DIFF
--- a/Restofire.xcodeproj/project.pbxproj
+++ b/Restofire.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		3504292D201CA2A000765D15 /* AStreamUploadableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3504292C201CA2A000765D15 /* AStreamUploadableSpec.swift */; };
 		3504292E201CA2A000765D15 /* AStreamUploadableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3504292C201CA2A000765D15 /* AStreamUploadableSpec.swift */; };
 		3504292F201CA2A000765D15 /* AStreamUploadableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3504292C201CA2A000765D15 /* AStreamUploadableSpec.swift */; };
+		351537372028441300165E83 /* RequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351537362028441300165E83 /* RequestDelegate.swift */; };
+		351537382028441300165E83 /* RequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351537362028441300165E83 /* RequestDelegate.swift */; };
+		351537392028441300165E83 /* RequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351537362028441300165E83 /* RequestDelegate.swift */; };
+		3515373A2028441300165E83 /* RequestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351537362028441300165E83 /* RequestDelegate.swift */; };
 		351AC43C1D75903A007C993C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 357C0DB31D75745F0096239A /* Alamofire.framework */; };
 		351AC43D1D759045007C993C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 357C0DBB1D75745F0096239A /* Alamofire.framework */; };
 		351AC43E1D75904F007C993C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 357C0DB71D75745F0096239A /* Alamofire.framework */; };
@@ -439,6 +443,7 @@
 		35042924201CA27200765D15 /* ADataUploadableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADataUploadableSpec.swift; sourceTree = "<group>"; };
 		35042928201CA29200765D15 /* AMultipartUploadableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AMultipartUploadableSpec.swift; sourceTree = "<group>"; };
 		3504292C201CA2A000765D15 /* AStreamUploadableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AStreamUploadableSpec.swift; sourceTree = "<group>"; };
+		351537362028441300165E83 /* RequestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDelegate.swift; sourceTree = "<group>"; };
 		35249B011D8E5A84005A2BAB /* DictionaryExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtension.swift; sourceTree = "<group>"; };
 		35366E8D1FFBB39E00270EDE /* TypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeAliases.swift; sourceTree = "<group>"; };
 		355389BB1D8E7FED001BDE66 /* RestofireTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RestofireTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -625,6 +630,7 @@
 				3593CA6B1D8C65E400075A15 /* Queueable.swift */,
 				35E6D3521CCBD50E007ABC05 /* Validatable.swift */,
 				358E8ED32020B776003048B3 /* Reachable.swift */,
+				351537362028441300165E83 /* RequestDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1247,6 +1253,7 @@
 				357E336E201DA1340093DCC5 /* JSONDecodableResponseSerializer.swift in Sources */,
 				357E33D4201DD7C50093DCC5 /* _Requestable.swift in Sources */,
 				357E3401201DDBFC0093DCC5 /* Configurable.swift in Sources */,
+				351537392028441300165E83 /* RequestDelegate.swift in Sources */,
 				35E6D3631CCBD75A007ABC05 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1298,6 +1305,7 @@
 				357E336D201DA1340093DCC5 /* JSONDecodableResponseSerializer.swift in Sources */,
 				357E33D3201DD7C50093DCC5 /* _Requestable.swift in Sources */,
 				357E3400201DDBFC0093DCC5 /* Configurable.swift in Sources */,
+				351537382028441300165E83 /* RequestDelegate.swift in Sources */,
 				35E6D3641CCBD75A007ABC05 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1349,6 +1357,7 @@
 				357E33D5201DD7C50093DCC5 /* _Requestable.swift in Sources */,
 				35E6D3651CCBD75A007ABC05 /* Authentication.swift in Sources */,
 				3594EB7B2021E4FB006FFA6A /* RequestOperation.swift in Sources */,
+				3515373A2028441300165E83 /* RequestDelegate.swift in Sources */,
 				3594EB7C2021E4FB006FFA6A /* DownloadOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1448,6 +1457,7 @@
 				357E336C201DA1340093DCC5 /* JSONDecodableResponseSerializer.swift in Sources */,
 				357E33D2201DD7C50093DCC5 /* _Requestable.swift in Sources */,
 				357E33FF201DDBFC0093DCC5 /* Configurable.swift in Sources */,
+				351537372028441300165E83 /* RequestDelegate.swift in Sources */,
 				35E6D3621CCBD75A007ABC05 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Alamofire/RestofireRequest.swift
+++ b/Sources/Alamofire/RestofireRequest.swift
@@ -12,36 +12,46 @@ class RestofireRequest {
     
     static func dataRequest<R: ARequestable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.DataRequest {
         let request = requestable.sessionManager.request(urlRequest)
+        didStart(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
         RestofireRequestValidation.validateDataRequest(request: request, requestable: requestable)
+        request.response { _ in didComplete(request, requestable: requestable) }
         return request
     }
     
     static func downloadRequest<R: ADownloadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.DownloadRequest {
         let request = requestable.sessionManager.download(urlRequest, to: requestable.destination)
+        didStart(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
         RestofireDownloadValidation.validateDownloadRequest(request: request, requestable: requestable)
+        request.response { _ in didComplete(request, requestable: requestable) }
         return request
     }
     
     static func fileUploadRequest<R: AFileUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
         let request = requestable.sessionManager.upload(requestable.url, with: urlRequest)
+        didStart(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
         RestofireRequestValidation.validateDataRequest(request: request, requestable: requestable)
+        request.response { _ in didComplete(request, requestable: requestable) }
         return request
     }
     
     static func dataUploadRequest<R: ADataUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
         let request = requestable.sessionManager.upload(requestable.data, with: urlRequest)
+        didStart(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
         RestofireRequestValidation.validateDataRequest(request: request, requestable: requestable)
+        request.response { _ in didComplete(request, requestable: requestable) }
         return request
     }
     
     static func streamUploadRequest<R: AStreamUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
         let request = requestable.sessionManager.upload(requestable.stream, with: urlRequest)
+        didStart(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
         RestofireRequestValidation.validateDataRequest(request: request, requestable: requestable)
+        request.response { _ in didComplete(request, requestable: requestable) }
         return request
     }
     
@@ -53,8 +63,13 @@ class RestofireRequest {
             with: urlRequest) { encodingCompletion in
                 switch encodingCompletion {
                 case .success(let request, let streamingFromDisk, let streamFileURL):
+                    didStart(request, requestable: requestable)
                     authenticateRequest(request, usingCredential: requestable.credential)
-                    RestofireRequestValidation.validateDataRequest(request: request, requestable: requestable)
+                    RestofireRequestValidation.validateDataRequest(
+                        request: request,
+                        requestable: requestable
+                    )
+                    request.response { _ in didComplete(request, requestable: requestable) }
                     let result = MultipartFormDataEncodingResult.success(request: request, streamingFromDisk: streamingFromDisk, streamFileURL: streamFileURL)
                     localEncodingCompletion?(result)
                 case .failure(_):
@@ -62,10 +77,27 @@ class RestofireRequest {
                 }
         }
     }
-
+    
     fileprivate static func authenticateRequest(_ request: Request, usingCredential credential: URLCredential?) {
         guard let credential = credential else { return }
         request.authenticate(usingCredential: credential)
     }
 
+    fileprivate static func didStart<R: AConfigurable>(_ request: Request, requestable: R) {
+        requestable.didStart(request)
+        if let delegates = requestable.delegates {
+            delegates.forEach { delegate in
+                delegate.didStart(request)
+            }
+        }
+    }
+    
+    fileprivate static func didComplete<R: AConfigurable>(_ request: Request, requestable: R) {
+        requestable.didComplete(request)
+        if let delegates = requestable.delegates {
+            delegates.forEach { delegate in
+                delegate.didComplete(request)
+            }
+        }
+    }
 }

--- a/Sources/Alamofire/RestofireRequest.swift
+++ b/Sources/Alamofire/RestofireRequest.swift
@@ -11,6 +11,7 @@ import Alamofire
 class RestofireRequest {
     
     static func dataRequest<R: ARequestable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.DataRequest {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let request = requestable.sessionManager.request(urlRequest)
         didSend(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
@@ -20,6 +21,7 @@ class RestofireRequest {
     }
     
     static func downloadRequest<R: ADownloadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.DownloadRequest {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let request = requestable.sessionManager.download(urlRequest, to: requestable.destination)
         didSend(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
@@ -29,6 +31,7 @@ class RestofireRequest {
     }
     
     static func fileUploadRequest<R: AFileUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let request = requestable.sessionManager.upload(requestable.url, with: urlRequest)
         didSend(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
@@ -38,6 +41,7 @@ class RestofireRequest {
     }
     
     static func dataUploadRequest<R: ADataUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let request = requestable.sessionManager.upload(requestable.data, with: urlRequest)
         didSend(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
@@ -47,6 +51,7 @@ class RestofireRequest {
     }
     
     static func streamUploadRequest<R: AStreamUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest) -> Alamofire.UploadRequest {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let request = requestable.sessionManager.upload(requestable.stream, with: urlRequest)
         didSend(request, requestable: requestable)
         authenticateRequest(request, usingCredential: requestable.credential)
@@ -56,6 +61,7 @@ class RestofireRequest {
     }
     
     static func multipartUploadRequest<R: AMultipartUploadable>(fromRequestable requestable: R, withUrlRequest urlRequest: URLRequest, encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)? = nil) {
+        let urlRequest = prepare(urlRequest, requestable: requestable)
         let localEncodingCompletion = encodingCompletion
         requestable.sessionManager.upload(
             multipartFormData: requestable.multipartFormData,
@@ -83,12 +89,13 @@ class RestofireRequest {
         request.authenticate(usingCredential: credential)
     }
     
-    fileprivate static func prepare<R: AConfigurable>(_ request: URLRequest, requestable: R) {
+    fileprivate static func prepare<R: AConfigurable>(_ request: URLRequest, requestable: R) -> URLRequest {
         var request = request
         request = requestable.prepare(request, requestable: requestable)
         requestable.delegates.forEach {
             request = $0.prepare(request, requestable: requestable)
         }
+        return request
     }
     
     fileprivate static func didSend<R: AConfigurable>(_ request: Request, requestable: R) {

--- a/Sources/AlamofireRequestable/AConfigurable.swift
+++ b/Sources/AlamofireRequestable/AConfigurable.swift
@@ -27,9 +27,6 @@ import Foundation
 /// ```
 public protocol AConfigurable: _Configurable, Authenticable, RequestDelegate, SessionManagable, Validatable {
     
-    /// The Alamofire Session Manager.
-    var sessionManager: SessionManager { get }
-    
     /// The credential.
     var credential: URLCredential? { get }
     
@@ -43,12 +40,7 @@ public protocol AConfigurable: _Configurable, Authenticable, RequestDelegate, Se
 
 // MARK: - Default Implementation
 public extension AConfigurable {
-    
-    /// `Session.default.sessionManager`
-    public var sessionManager: SessionManager {
-        return _sessionManager
-    }
-    
+
     /// `Authentication.default.credential`
     public var credential: URLCredential? {
         return authentication.credential

--- a/Sources/AlamofireRequestable/AConfigurable.swift
+++ b/Sources/AlamofireRequestable/AConfigurable.swift
@@ -25,7 +25,7 @@ import Foundation
 ///
 /// }
 /// ```
-public protocol AConfigurable: _Configurable, Authenticable, SessionManagable, Validatable {
+public protocol AConfigurable: _Configurable, Authenticable, RequestDelegate, SessionManagable, Validatable {
     
     /// The Alamofire Session Manager.
     var sessionManager: SessionManager { get }
@@ -63,6 +63,6 @@ public extension AConfigurable {
     public var acceptableContentTypes: [String]? {
         return validation.acceptableContentTypes
     }
-    
+
 }
 

--- a/Sources/AlamofireRequestable/AConfigurable.swift
+++ b/Sources/AlamofireRequestable/AConfigurable.swift
@@ -36,25 +36,33 @@ public protocol AConfigurable: _Configurable, Authenticable, RequestDelegate, Se
     /// The acceptable content types.
     var acceptableContentTypes: [String]? { get }
     
+    /// The request delegates.
+    var delegates: [RequestDelegate] { get }
+    
 }
 
 // MARK: - Default Implementation
 public extension AConfigurable {
 
-    /// `Authentication.default.credential`
+    /// `nil`
     public var credential: URLCredential? {
         return authentication.credential
     }
     
-    /// `Validation.default.acceptableStatusCodes`
+    /// `nil`
     public var acceptableStatusCodes: [Int]? {
         return validation.acceptableStatusCodes
     }
     
-    /// `Validation.default.acceptableContentTypes`
+    /// `nil`
     public var acceptableContentTypes: [String]? {
         return validation.acceptableContentTypes
     }
 
+    /// `empty`
+    public var delegates: [RequestDelegate] {
+        return configuration.requestDelegates
+    }
+    
 }
 

--- a/Sources/AlamofireRequestable/ARequestable.swift
+++ b/Sources/AlamofireRequestable/ARequestable.swift
@@ -31,6 +31,7 @@ public extension ARequestable {
     public var validationBlock: DataRequest.Validation? {
         return validation.dataValidation
     }
+    
 }
 
 public extension ARequestable {

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -43,6 +43,9 @@ public struct Configuration {
     /// The HTTP headers. `nil` by default.
     public var headers: [String : String] = [:]
     
+    /// The request parameter encoding. `.JSON` by default.
+    public var requestDelegates: [RequestDelegate] = []
+    
     /// `Configuration` Intializer
     ///
     /// - returns: new `Configuration` object

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -43,7 +43,7 @@ public struct Configuration {
     /// The HTTP headers. `nil` by default.
     public var headers: [String : String] = [:]
     
-    /// The request parameter encoding. `.JSON` by default.
+    /// The request delegates. `empty` by default.
     public var requestDelegates: [RequestDelegate] = []
     
     /// `Configuration` Intializer

--- a/Sources/Configuration/Protocols/Queueable.swift
+++ b/Sources/Configuration/Protocols/Queueable.swift
@@ -12,14 +12,14 @@ import Foundation
 public protocol Queueable {
     
     /// The `queue`.
-    var _queue: DispatchQueue { get }
+    var queue: DispatchQueue { get }
     
 }
 
 public extension Queueable where Self: Configurable {
     
     /// `DispatchQueue.main`
-    public var _queue: DispatchQueue {
+    public var queue: DispatchQueue {
         return DispatchQueue.main
     }
     

--- a/Sources/Configuration/Protocols/RequestDelegate.swift
+++ b/Sources/Configuration/Protocols/RequestDelegate.swift
@@ -1,0 +1,38 @@
+//
+//  RequestDelegate.swift
+//  Restofire
+//
+//  Created by Rahul Katariya on 05/02/18.
+//  Copyright © 2018 AarKay. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a `RequestDelegate` that is associated with `Requestable`.
+public protocol RequestDelegate {
+    
+    /// The request delegates
+    var delegates: [RequestDelegate]? { get }
+    
+    /// A delegate method called when the request is created.
+    func didStart(_ request: Request)
+    
+    /// A delegate method called when the request is completed.
+    func didComplete(_ request: Request)
+    
+}
+
+extension RequestDelegate {
+    
+    /// `nil`
+    public var delegates: [RequestDelegate]? {
+        return nil
+    }
+    
+    /// `Noop`
+    public func didStart(_ request: Request) {}
+    
+    /// `Noop`
+    public func didComplete(_ request: Request) {}
+    
+}

--- a/Sources/Configuration/Protocols/RequestDelegate.swift
+++ b/Sources/Configuration/Protocols/RequestDelegate.swift
@@ -11,28 +11,28 @@ import Foundation
 /// Represents a `RequestDelegate` that is associated with `Requestable`.
 public protocol RequestDelegate {
     
-    /// The request delegates
-    var delegates: [RequestDelegate]? { get }
+    /// Called to modify a request before sending.
+    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest
     
-    /// A delegate method called when the request is created.
-    func didStart(_ request: Request)
+    /// Called when the request is sent over the network.
+    func didSend(_ request: Request, requestable: AConfigurable)
     
-    /// A delegate method called when the request is completed.
-    func didComplete(_ request: Request)
+    /// Called when the request is completed.
+    func didComplete(_ request: Request, requestable: AConfigurable)
     
 }
 
 extension RequestDelegate {
     
-    /// `nil`
-    public var delegates: [RequestDelegate]? {
-        return nil
+    /// `No-op`
+    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+        return request
     }
     
-    /// `Noop`
-    public func didStart(_ request: Request) {}
+    /// `No-op`
+    public func didSend(_ request: Request, requestable: AConfigurable) {}
     
-    /// `Noop`
-    public func didComplete(_ request: Request) {}
+    /// `No-op`
+    public func didComplete(_ request: Request, requestable: AConfigurable) {}
     
 }

--- a/Sources/Configuration/Protocols/SessionManagable.swift
+++ b/Sources/Configuration/Protocols/SessionManagable.swift
@@ -12,14 +12,14 @@ import Foundation
 public protocol SessionManagable {
     
     /// The `sessionManager`.
-    var _sessionManager: SessionManager { get }
+    var sessionManager: SessionManager { get }
     
 }
 
 public extension SessionManagable where Self: AConfigurable {
     
     /// `Session.default`
-    public var _sessionManager: SessionManager {
+    public var sessionManager: SessionManager {
         return Session.default.sessionManager
     }
     

--- a/Sources/Requestable/Configurable.swift
+++ b/Sources/Requestable/Configurable.swift
@@ -47,9 +47,6 @@ public protocol Configurable: AConfigurable, Reachable, Retryable, Queueable {
     /// The max retry attempts.
     var maxRetryAttempts: Int { get }
     
-    /// The queue on which reponse will be delivered.
-    var queue: DispatchQueue? { get }
-    
 }
 
 // MARK: - Default Implementation
@@ -86,10 +83,5 @@ public extension Configurable {
     public var maxRetryAttempts: Int {
         return retry.maxRetryAttempts
     }
-    
-    /// `Queueable.queue`
-    public var queue: DispatchQueue? {
-        return _queue
-    }
-    
+
 }

--- a/Tests/AlamofireRequestable/ADataUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADataUploadableSpec.swift
@@ -28,7 +28,16 @@ class ADataUploadableSpec: BaseSpec {
                         return "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".data(using: .utf8, allowLossyConversion: false)!
                     }()
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         ADataUploadableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/ADataUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADataUploadableSpec.swift
@@ -14,6 +14,9 @@ import Alamofire
 
 class ADataUploadableSpec: BaseSpec {
     
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
+    
     override func spec() {
         describe("ADataUpload") {
             
@@ -24,10 +27,22 @@ class ADataUploadableSpec: BaseSpec {
                     var data: Data = {
                         return "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".data(using: .utf8, allowLossyConversion: false)!
                     }()
+                    
+                    func didStart(_ request: Request) {
+                        ADataUploadableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        ADataUploadableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 let request = Upload().request
                 print(request.debugDescription)
+                
+                expect(ADataUploadableSpec.startDelegateCalled).to(beTrue())
+                
                 var uploadProgressValues: [Double] = []
                 var downloadProgressValues: [Double] = []
                 
@@ -44,6 +59,8 @@ class ADataUploadableSpec: BaseSpec {
                             defer { done() }
                             
                             // Then
+                            expect(ADataUploadableSpec.completeDelegateCalled).to(beTrue())
+                            
                             if let statusCode = response.response?.statusCode,
                                 statusCode != 200 {
                                 fail("Response status code should be 200")
@@ -71,7 +88,7 @@ class ADataUploadableSpec: BaseSpec {
                             if let lastUploadProgressValue = uploadProgressValues.last {
                                 expect(lastUploadProgressValue).to(equal(1.0))
                             } else {
-                                fail("last item in progressValues should not be nil")
+                                fail("last item in uploadProgressValues should not be nil")
                             }
                             
                             var previousDownloadProgress: Double = downloadProgressValues.first ?? 0.0
@@ -84,7 +101,7 @@ class ADataUploadableSpec: BaseSpec {
                             if let lastDownloadProgressValue = downloadProgressValues.last {
                                 expect(lastDownloadProgressValue).to(equal(1.0))
                             } else {
-                                fail("last item in progressValues should not be nil")
+                                fail("last item in downloadProgressValues should not be nil")
                             }
                     }
                 }

--- a/Tests/AlamofireRequestable/ADataUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADataUploadableSpec.swift
@@ -28,11 +28,11 @@ class ADataUploadableSpec: BaseSpec {
                         return "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".data(using: .utf8, allowLossyConversion: false)!
                     }()
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         ADataUploadableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         ADataUploadableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/ADownloadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADownloadableSpec.swift
@@ -30,7 +30,16 @@ class ADownloadableSpec: BaseSpec {
                         self.destination = destination
                     }
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         ADownloadableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/ADownloadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADownloadableSpec.swift
@@ -14,6 +14,9 @@ import Alamofire
 
 class ADownloadableSpec: BaseSpec {
     
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
+    
     override func spec() {
         describe("Download") {
             
@@ -26,10 +29,22 @@ class ADownloadableSpec: BaseSpec {
                     init(destination: @escaping DownloadFileDestination) {
                         self.destination = destination
                     }
+                    
+                    func didStart(_ request: Request) {
+                        ADownloadableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        ADownloadableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 let request = Download(destination: { _, _ in (BaseSpec.jsonFileURL, []) }).request()
                 print(request.debugDescription)
+                
+                expect(ADownloadableSpec.startDelegateCalled).to(beTrue())
+                
                 var progressValues: [Double] = []
                 
                 // When
@@ -42,6 +57,8 @@ class ADownloadableSpec: BaseSpec {
                             defer { done() }
                             
                             // Then
+                            expect(ADownloadableSpec.completeDelegateCalled).to(beTrue())
+                            
                             if let statusCode = response.response?.statusCode,
                                 statusCode != 200 {
                                 fail("Response status code should be 200")

--- a/Tests/AlamofireRequestable/ADownloadableSpec.swift
+++ b/Tests/AlamofireRequestable/ADownloadableSpec.swift
@@ -30,11 +30,11 @@ class ADownloadableSpec: BaseSpec {
                         self.destination = destination
                     }
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         ADownloadableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         ADownloadableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AFileUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AFileUploadableSpec.swift
@@ -14,6 +14,9 @@ import Alamofire
 
 class AFileUploadableSpec: BaseSpec {
     
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
+    
     override func spec() {
         describe("AFileUpload") {
             
@@ -22,9 +25,22 @@ class AFileUploadableSpec: BaseSpec {
                 struct Upload: AFileUploadable {
                     var path: String? = "post"
                     let url: URL = BaseSpec.url(forResource: "rainbow", withExtension: "jpg")
+                    
+                    func didStart(_ request: Request) {
+                        AFileUploadableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        AFileUploadableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 let request = Upload().request
+                print(request.debugDescription)
+                
+                expect(AFileUploadableSpec.startDelegateCalled).to(beTrue())
+                
                 var uploadProgressValues: [Double] = []
                 var downloadProgressValues: [Double] = []
                 
@@ -41,6 +57,8 @@ class AFileUploadableSpec: BaseSpec {
                             defer { done() }
                             
                             // Then
+                            expect(AFileUploadableSpec.completeDelegateCalled).to(beTrue())
+                            
                             if let statusCode = response.response?.statusCode,
                                 statusCode != 200 {
                                 fail("Response status code should be 200")
@@ -68,7 +86,7 @@ class AFileUploadableSpec: BaseSpec {
                             if let lastUploadProgressValue = uploadProgressValues.last {
                                 expect(lastUploadProgressValue).to(equal(1.0))
                             } else {
-                                fail("last item in progressValues should not be nil")
+                                fail("last item in uploadProgressValues should not be nil")
                             }
                             
                             var previousDownloadProgress: Double = downloadProgressValues.first ?? 0.0
@@ -81,7 +99,7 @@ class AFileUploadableSpec: BaseSpec {
                             if let lastDownloadProgressValue = downloadProgressValues.last {
                                 expect(lastDownloadProgressValue).to(equal(1.0))
                             } else {
-                                fail("last item in progressValues should not be nil")
+                                fail("last item in downloadProgressValues should not be nil")
                             }
                     }
                 }

--- a/Tests/AlamofireRequestable/AFileUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AFileUploadableSpec.swift
@@ -26,7 +26,16 @@ class AFileUploadableSpec: BaseSpec {
                     var path: String? = "post"
                     let url: URL = BaseSpec.url(forResource: "rainbow", withExtension: "jpg")
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         AFileUploadableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AFileUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AFileUploadableSpec.swift
@@ -26,11 +26,11 @@ class AFileUploadableSpec: BaseSpec {
                     var path: String? = "post"
                     let url: URL = BaseSpec.url(forResource: "rainbow", withExtension: "jpg")
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         AFileUploadableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         AFileUploadableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
@@ -31,7 +31,16 @@ class AMultipartUploadableSpec: BaseSpec {
                         multipartFormData.append(BaseSpec.url(forResource: "unicorn", withExtension: "png"), withName: "image")
                     }
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         AMultipartUploadableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
@@ -31,11 +31,11 @@ class AMultipartUploadableSpec: BaseSpec {
                         multipartFormData.append(BaseSpec.url(forResource: "unicorn", withExtension: "png"), withName: "image")
                     }
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         AMultipartUploadableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         AMultipartUploadableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AMultipartUploadableSpec.swift
@@ -14,6 +14,9 @@ import Alamofire
 
 class AMultipartUploadableSpec: BaseSpec {
     
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
+    
     override func spec() {
         describe("AMultipartUpload") {
             
@@ -27,6 +30,15 @@ class AMultipartUploadableSpec: BaseSpec {
                         multipartFormData.append(BaseSpec.url(forResource: "rainbow", withExtension: "jpg"), withName: "image")
                         multipartFormData.append(BaseSpec.url(forResource: "unicorn", withExtension: "png"), withName: "image")
                     }
+                    
+                    func didStart(_ request: Request) {
+                        AMultipartUploadableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        AMultipartUploadableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 // When
@@ -36,6 +48,9 @@ class AMultipartUploadableSpec: BaseSpec {
                         case .success(let upload, _, _):
                             
                             print(upload.debugDescription)
+                            
+                            expect(AMultipartUploadableSpec.startDelegateCalled).to(beTrue())
+                            
                             var uploadProgressValues: [Double] = []
                             var downloadProgressValues: [Double] = []
                             
@@ -50,6 +65,8 @@ class AMultipartUploadableSpec: BaseSpec {
                                     defer { done() }
                                     
                                     // Then
+                                    expect(AMultipartUploadableSpec.completeDelegateCalled).to(beTrue())
+                                    
                                     if let statusCode = response.response?.statusCode,
                                         statusCode != 200 {
                                         fail("Response status code should be 200")
@@ -80,7 +97,7 @@ class AMultipartUploadableSpec: BaseSpec {
                                     if let lastUploadProgressValue = uploadProgressValues.last {
                                         expect(lastUploadProgressValue).to(equal(1.0))
                                     } else {
-                                        fail("last item in progressValues should not be nil")
+                                        fail("last item in uploadProgressValues should not be nil")
                                     }
                                     
                                     var previousDownloadProgress: Double = downloadProgressValues.first ?? 0.0
@@ -93,7 +110,7 @@ class AMultipartUploadableSpec: BaseSpec {
                                     if let lastDownloadProgressValue = downloadProgressValues.last {
                                         expect(lastDownloadProgressValue).to(equal(1.0))
                                     } else {
-                                        fail("last item in progressValues should not be nil")
+                                        fail("last item in downloadProgressValues should not be nil")
                                     }
                             }
                         case .failure(let error):

--- a/Tests/AlamofireRequestable/ARequestableSpec.swift
+++ b/Tests/AlamofireRequestable/ARequestableSpec.swift
@@ -25,7 +25,16 @@ class ARequestableSpec: BaseSpec {
                 struct Service: ARequestable {
                     var path: String? = "get"
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         ARequestableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/ARequestableSpec.swift
+++ b/Tests/AlamofireRequestable/ARequestableSpec.swift
@@ -25,11 +25,11 @@ class ARequestableSpec: BaseSpec {
                 struct Service: ARequestable {
                     var path: String? = "get"
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         ARequestableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         ARequestableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/ARequestableSpec.swift
+++ b/Tests/AlamofireRequestable/ARequestableSpec.swift
@@ -14,6 +14,9 @@ import Alamofire
 
 class ARequestableSpec: BaseSpec {
     
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
+    
     override func spec() {
         describe("ARequestable") {
             
@@ -21,10 +24,22 @@ class ARequestableSpec: BaseSpec {
                 // Given
                 struct Service: ARequestable {
                     var path: String? = "get"
+                    
+                    func didStart(_ request: Request) {
+                        ARequestableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        ARequestableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 let request = Service().request
                 print(request.debugDescription)
+                
+                expect(ARequestableSpec.startDelegateCalled).to(beTrue())
+                
                 var progressValues: [Double] = []
                 
                 // When
@@ -35,6 +50,8 @@ class ARequestableSpec: BaseSpec {
                         }
                         .responseJSON { response in
                             defer { done() }
+                            
+                            expect(ARequestableSpec.completeDelegateCalled).to(beTrue())
                             
                             // Then
                             if let statusCode = response.response?.statusCode,

--- a/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
@@ -26,11 +26,11 @@ class AStreamUploadableSpec: BaseSpec {
                     var path: String? = "post"
                     var stream: InputStream = InputStream(url: BaseSpec.url(forResource: "rainbow", withExtension: "jpg"))!
                     
-                    func didStart(_ request: Request) {
+                    func didSend(_ request: Request, requestable: AConfigurable) {
                         AStreamUploadableSpec.startDelegateCalled = true
                     }
                     
-                    func didComplete(_ request: Request) {
+                    func didComplete(_ request: Request, requestable: AConfigurable) {
                         AStreamUploadableSpec.completeDelegateCalled = true
                     }
                     

--- a/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
@@ -13,6 +13,9 @@ import Alamofire
 @testable import Restofire
 
 class AStreamUploadableSpec: BaseSpec {
+    
+    static var startDelegateCalled = false
+    static var completeDelegateCalled = false
 
     override func spec() {
         describe("AStreamUpload") {
@@ -22,10 +25,21 @@ class AStreamUploadableSpec: BaseSpec {
                 struct Upload: AStreamUploadable {
                     var path: String? = "post"
                     var stream: InputStream = InputStream(url: BaseSpec.url(forResource: "rainbow", withExtension: "jpg"))!
+                    
+                    func didStart(_ request: Request) {
+                        AStreamUploadableSpec.startDelegateCalled = true
+                    }
+                    
+                    func didComplete(_ request: Request) {
+                        AStreamUploadableSpec.completeDelegateCalled = true
+                    }
+                    
                 }
                 
                 let request = Upload().request
                 print(request.debugDescription)
+                
+                expect(AStreamUploadableSpec.startDelegateCalled).to(beTrue())
                 
                 // When
                 waitUntil(timeout: self.timeout) { done in
@@ -33,9 +47,9 @@ class AStreamUploadableSpec: BaseSpec {
                         .response { response in
                             defer { done() }
                             
-                            print(response)
-                            
                             // Then
+                            expect(AStreamUploadableSpec.completeDelegateCalled).to(beTrue())
+                            
                             expect(response.request).toNot(beNil())
                             expect(response.response).toNot(beNil())
                             expect(response.data).toNot(beNil())

--- a/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
+++ b/Tests/AlamofireRequestable/AStreamUploadableSpec.swift
@@ -26,7 +26,16 @@ class AStreamUploadableSpec: BaseSpec {
                     var path: String? = "post"
                     var stream: InputStream = InputStream(url: BaseSpec.url(forResource: "rainbow", withExtension: "jpg"))!
                     
+                    func prepare(_ request: URLRequest, requestable: AConfigurable) -> URLRequest {
+                        var request = request
+                        let header = Request.authorizationHeader(user: "user", password: "password")!
+                        request.setValue(header.value, forHTTPHeaderField: header.key)
+                        return request
+                    }
+                    
                     func didSend(_ request: Request, requestable: AConfigurable) {
+                        expect(request.request?.value(forHTTPHeaderField: "Authorization"))
+                            .to(equal("Basic dXNlcjpwYXNzd29yZA=="))
                         AStreamUploadableSpec.startDelegateCalled = true
                     }
                     

--- a/Tests/Requestable/DataUploadableSpec.swift
+++ b/Tests/Requestable/DataUploadableSpec.swift
@@ -85,7 +85,7 @@ class DataUploadableSpec: BaseSpec {
                         if let lastUploadProgressValue = DataUploadableSpec.uploadProgressValues.last {
                             expect(lastUploadProgressValue).to(equal(1.0))
                         } else {
-                            fail("last item in progressValues should not be nil")
+                            fail("last item in uploadProgressValues should not be nil")
                         }
                         
                         var previousDownloadProgress: Double = DataUploadableSpec.downloadProgressValues.first ?? 0.0
@@ -98,7 +98,7 @@ class DataUploadableSpec: BaseSpec {
                         if let lastDownloadProgressValue = DataUploadableSpec.downloadProgressValues.last {
                             expect(lastDownloadProgressValue).to(equal(1.0))
                         } else {
-                            fail("last item in progressValues should not be nil")
+                            fail("last item in downloadProgressValues should not be nil")
                         }
                         
                         done()

--- a/Tests/Requestable/FileUploadableSpec.swift
+++ b/Tests/Requestable/FileUploadableSpec.swift
@@ -82,7 +82,7 @@ class FileUploadableSpec: BaseSpec {
                         if let lastUploadProgressValue = FileUploadableSpec.uploadProgressValues.last {
                             expect(lastUploadProgressValue).to(equal(1.0))
                         } else {
-                            fail("last item in progressValues should not be nil")
+                            fail("last item in uploadProgressValues should not be nil")
                         }
                         
                         var previousDownloadProgress: Double = FileUploadableSpec.downloadProgressValues.first ?? 0.0
@@ -95,7 +95,7 @@ class FileUploadableSpec: BaseSpec {
                         if let lastDownloadProgressValue = FileUploadableSpec.downloadProgressValues.last {
                             expect(lastDownloadProgressValue).to(equal(1.0))
                         } else {
-                            fail("last item in progressValues should not be nil")
+                            fail("last item in downloadProgressValues should not be nil")
                         }
                         
                         done()

--- a/Tests/Requestable/MultipartUploadableSpec.swift
+++ b/Tests/Requestable/MultipartUploadableSpec.swift
@@ -109,7 +109,7 @@ class MultipartUploadableSpec: BaseSpec {
                                 if let lastUploadProgressValue = MultipartUploadableSpec.uploadProgressValues.last {
                                     expect(lastUploadProgressValue).to(equal(1.0))
                                 } else {
-                                    fail("last item in progressValues should not be nil")
+                                    fail("last item in uploadProgressValues should not be nil")
                                 }
                                 
                                 var previousDownloadProgress: Double = MultipartUploadableSpec.downloadProgressValues.first ?? 0.0
@@ -122,7 +122,7 @@ class MultipartUploadableSpec: BaseSpec {
                                 if let lastDownloadProgressValue = MultipartUploadableSpec.downloadProgressValues.last {
                                     expect(lastDownloadProgressValue).to(equal(1.0))
                                 } else {
-                                    fail("last item in progressValues should not be nil")
+                                    fail("last item in downloadProgressValues should not be nil")
                                 }
                                 
                                 done()


### PR DESCRIPTION
### Issue Link :link:
#32 

### Goals :soccer:
Allow requests to be modified and notify when sent and completed.
Inspired by @moya Plugins

### Implementation Details :construction:
A configurable can have array of request delegates with no-op as default implementation.
Each Requestable can also conforms to request delegate

### Testing Details :mag:
Tests added for all protocols compatible with Alamofire
